### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@
 # Runs on every push and pull request to validate builds and tests
 
 name: CI - Build and Test
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/deploy-android.yml
+++ b/.github/workflows/deploy-android.yml
@@ -2,6 +2,8 @@
 # Builds and publishes the MAUI Android app (APK)
 
 name: Deploy Android App
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/deploy-api.yml
+++ b/.github/workflows/deploy-api.yml
@@ -2,6 +2,8 @@
 # Builds and publishes the ASP.NET Core API for deployment
 
 name: Deploy API
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:

--- a/.github/workflows/deploy-windows.yml
+++ b/.github/workflows/deploy-windows.yml
@@ -2,6 +2,8 @@
 # Builds and publishes the MAUI Windows desktop app (MSIX)
 
 name: Deploy Windows App
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/mistalan/Terminplaner/security/code-scanning/9](https://github.com/mistalan/Terminplaner/security/code-scanning/9)

To address this issue, we should add a `permissions` block to the workflow to enforce the principle of least privilege. As none of the existing steps require write access to repository contents, and upload actions don't require content write permissions, the safest default is `contents: read`. This setting should be added at the root level of the workflow (before the `jobs:` block) so it applies to all jobs unless overridden. Edit `.github/workflows/deploy-windows.yml` to introduce this block directly beneath the `name:` field (after line 4).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
